### PR TITLE
 Fixed constant overflows int

### DIFF
--- a/assign/common.go
+++ b/assign/common.go
@@ -28,7 +28,7 @@ func setHdrOffset(valueType constants.DataType, valueLength int, buf []byte, o i
 	o++
 
 	// extra large header content
-	buf[o] = byte((uint64(valueLength) & 0xff000000) >> 24)
+	buf[o] = byte((int64(valueLength) & 0xff000000) >> 24)
 	o++
 	buf[o] = 0
 	o++
@@ -45,7 +45,7 @@ func SetInt(v int, buf []byte, o int) {
 	o++
 	buf[o] = byte((v & 0xff0000) >> 16)
 	o++
-	buf[o] = byte((uint64(v) & 0xff000000) >> 24)
+	buf[o] = byte((int64(v) & 0xff000000) >> 24)
 	o++
 }
 

--- a/assign/common.go
+++ b/assign/common.go
@@ -28,7 +28,7 @@ func setHdrOffset(valueType constants.DataType, valueLength int, buf []byte, o i
 	o++
 
 	// extra large header content
-	buf[o] = byte((valueLength & 0xff000000) >> 24)
+	buf[o] = byte((uint64(valueLength) & 0xff000000) >> 24)
 	o++
 	buf[o] = 0
 	o++
@@ -45,7 +45,7 @@ func SetInt(v int, buf []byte, o int) {
 	o++
 	buf[o] = byte((v & 0xff0000) >> 16)
 	o++
-	buf[o] = byte((v & 0xff000000) >> 24)
+	buf[o] = byte((uint64(v) & 0xff000000) >> 24)
 	o++
 }
 


### PR DESCRIPTION
fixed #34, test output is a PASS.
I had to convert the integer to an int64 in order to compile in go 1.9.1