### PR TITLE
Added public GetError method to the packet.

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -19,6 +19,10 @@ type Packet interface {
 
 	// IsError returns a boolean defining whether the Packet contains an error.
 	IsError() bool
+
+	// Returns the packet's error or nil if there is none.
+	GetError() error
+
 	// IsOk returns a boolean defining whether Packet was success
 	IsOk() bool
 }
@@ -52,6 +56,14 @@ func (p *packet) IsOk() bool {
 
 func (p *packet) getStatusCode() int {
 	return p.cmd >> 24 & 127
+}
+
+func (p *packet) GetError() error {
+	if p.IsError() {
+		return p.getError()
+	} else {
+		return nil
+	}
 }
 
 func (p *packet) getError() error {

--- a/packet_test.go
+++ b/packet_test.go
@@ -14,6 +14,22 @@ func TestErrorPacketIsError(t *testing.T) {
 	}
 }
 
+func TestErrorPacketGetErrorNonNil(t *testing.T) {
+	pkt := newErrorPacket(errors.New("test error"))
+	err := pkt.GetError()
+	if err == nil {
+		t.Error("GetError should return a non nil error when the packet has an error")
+	}
+}
+
+func TestErrorPacketGetErrorNil(t *testing.T) {
+	pkt := newErrorPacket(nil)
+	err := pkt.GetError()
+	if err != nil {
+		t.Error("GetError should return nil when the packet has no error")
+	}
+}
+
 func TestErrorPacketResultObject(t *testing.T) {
 	testError := errors.New("test error")
 	pkt := newErrorPacket(testError)


### PR DESCRIPTION
Before the only way for the user to get the error was to call
GetResultObject. However, the parse would also be called in this
case and then the user wouldn't know (programatically) where the error
came from. Off course, the librarie's user could make some string
matching to try to deduce, but this is error prone and non scalable.